### PR TITLE
Feature/bip0070 bitpay

### DIFF
--- a/wallet/src/de/schildbach/wallet/data/PaymentIntent.java
+++ b/wallet/src/de/schildbach/wallet/data/PaymentIntent.java
@@ -367,10 +367,12 @@ public final class PaymentIntent implements Parcelable {
      * @return true if it extends
      */
     public boolean isExtendedBy(final PaymentIntent other) {
-        // shortcut via hash
-        if (standard == Standard.BIP21 && other.standard == Standard.BIP70)
-            if (paymentRequestHash != null && Arrays.equals(paymentRequestHash, other.paymentRequestHash))
-                return true;
+        // shortcut non-backwards compatible BIP0072
+        if (standard == Standard.BIP21 && other.standard == Standard.BIP70) {
+            final boolean hasAddressConflict = hasAddress() && !equalsAddress(other);
+            final boolean hasAmountConflict = hasAmount() && !equalsAmount(other);
+            return !(hasAddressConflict || hasAmountConflict);
+        }
 
         // TODO memo
         return equalsAmount(other) && equalsAddress(other);

--- a/wallet/src/de/schildbach/wallet/data/PaymentIntent.java
+++ b/wallet/src/de/schildbach/wallet/data/PaymentIntent.java
@@ -360,7 +360,8 @@ public final class PaymentIntent implements Parcelable {
      * Check if given payment intent is only extending on <i>this</i> one, that is it does not alter any of
      * the fields. Address and amount fields must be equal, respectively (non-existence included).
      * 
-     * Alternatively, a BIP21+BIP72 request can provide a hash of the BIP70 request.
+     * Alternatively, a BIP21+BIP72 request can extend <i>this</i> one to add non-existent fields,
+     * but must include equal values for redundant fields.
      * 
      * @param other
      *            payment intent that is checked if it extends this one

--- a/wallet/src/de/schildbach/wallet/ui/InputParser.java
+++ b/wallet/src/de/schildbach/wallet/ui/InputParser.java
@@ -82,7 +82,7 @@ public abstract class InputParser {
         public void parse() {
             if (input.startsWith("BITCOINCASH:-")) {
                 try {
-                    final byte[] serializedPaymentRequest = Qr.decodeBinary(input.substring(9));
+                    final byte[] serializedPaymentRequest = Qr.decodeBinary(input.substring(13));
 
                     parseAndHandlePaymentRequest(serializedPaymentRequest);
                 } catch (final IOException x) {


### PR DESCRIPTION
This PR enables BIP0070 payments to BIP0072 compliant URIs that are not backwards compatible with BIP0021 URIs (e.g. Bitpay invoices). For payment URIs that have an address field, an amount field, or both, validation is done to ensure values of such match those parsed from the payment url response.